### PR TITLE
Image to storage

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -37,7 +37,7 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -37,7 +37,7 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,9 @@
     package="com.neastwest.imagesiphon">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_INTERNAL_STORAGE" />
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/com/neastwest/imagesiphon/ImageSiphon.java
+++ b/app/src/main/java/com/neastwest/imagesiphon/ImageSiphon.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.media.ThumbnailUtils;
+import android.net.Uri;
 import android.util.Log;
 import android.view.View;
 import android.widget.ImageView;
@@ -54,25 +55,20 @@ public class ImageSiphon {
         return thumb;
     }
 
-    public static View viewCreator(MainActivity.Wrapper w) throws MalformedURLException, IOException {
+    public static MainActivity.ImageDL viewCreator(MainActivity.Wrapper w) throws IOException {
+        MainActivity.ImageDL dl = new MainActivity.ImageDL();
         Context context = w.getContext();
         URL url = new URL(w.getString());
-        String packageName = w.getPackageName();
         Bitmap newImage;
         //if the URL returns a good HTTP response code, retrieve the
         //image from the URL and then turn it into an ImageView
         if (testURL(url)) {
-            Log.d("MESSAGE", "good URL: ");
-            newImage = retrieveImage(url);
-            Log.d("MESSAGE", "calling save image function");
-            saveThumbToFile(newImage, context);
-            View imgView = createImageView(newImage, context);
-            return imgView;
+            dl = goodURL(url, context, dl);
+            return dl;
             //Else return an error TextView
         } else {
-            Log.d("MESSAGE", "bad URL: ");
-            View txtView = createErrorTextView(context);
-            return txtView;
+            dl = badURL(context, dl);
+            return dl;
         }
     }
     //Method to get the HTTP Response Code from a URL and return true if it is a 200
@@ -101,6 +97,29 @@ public class ImageSiphon {
         //Return true if responseCode is 200
        return true;
     }
+    private static MainActivity.ImageDL badURL(Context context, MainActivity.ImageDL dl) {
+        Log.d("MESSAGE", "bad URL: ");
+        View txtView = createErrorTextView(context);
+        dl.setView(txtView);
+        dl.setImgOrTxt(false);
+
+        return dl;
+    }
+
+    private static MainActivity.ImageDL goodURL(URL url, Context context, MainActivity.ImageDL dl)
+            throws IOException {
+        Bitmap newImage;
+        Log.d("MESSAGE", "good URL: ");
+        newImage = retrieveImage(url);
+        Log.d("MESSAGE", "calling save image function");
+        File newThumbFile = getOutputMediaFile(context);
+        dl.setThumb(Uri.fromFile(newThumbFile));
+        saveThumbToFile(newImage, context, newThumbFile);
+        View imgView = createImageView(newThumbFile, context);
+        dl.setView(imgView);
+
+        return dl;
+    }
     private static Bitmap createThumb(Bitmap image) {
        // int dimension = getSquareCropDimensionForBitmap(image);
         Bitmap bitmap = ThumbnailUtils.extractThumbnail(image, 750, 750);
@@ -122,15 +141,16 @@ public class ImageSiphon {
         return newTxtView;
     }
 
-    public static View createImageView(Bitmap image, Context context) {
+    public static View createImageView(File image, Context context) {
+        Uri uri = Uri.fromFile(image);
         ImageView newImgView = new ImageView(context);
-        newImgView.setImageBitmap(image);
+        newImgView.setImageURI(uri);
         newImgView.setPadding(5, 5, 5, 5);
         return newImgView;
     }
 
-    public static void saveThumbToFile(Bitmap image, Context context) {
-        File pictureFile = getOutputMediaFile(context);
+    public static void saveThumbToFile(Bitmap image, Context context, File pictureFile) {
+        //File pictureFile = getOutputMediaFile(context);
         if (pictureFile == null) {
             Log.d(TAG,
                     "Error creating media file, check storage permissions: ");// e.getMessage());
@@ -140,7 +160,6 @@ public class ImageSiphon {
             FileOutputStream fos = new FileOutputStream(pictureFile);
             image.compress(Bitmap.CompressFormat.PNG, 90, fos);
             fos.close();
-            Log.d("MESSAGE", pictureFile.toString());
         } catch (FileNotFoundException e) {
             Log.d(TAG, "File not found: " + e.getMessage());
         } catch (IOException e) {
@@ -153,7 +172,7 @@ public class ImageSiphon {
         Log.d("MESSAGE", "reached output media file");
         // To be safe, you should check that the SDCard is mounted
         // using Environment.getExternalStorageState() before doing this.
-        File mediaStorageDir = new File(context.getFilesDir().getPath() + "/pics/");
+        File mediaStorageDir = new File(context.getFilesDir().getPath() + "/THUMBS/");
         Log.d("MESSAGE", "saved storage dir");
         // This location works best if you want the created images to be shared
         // between applications and persist after your app has been uninstalled.

--- a/app/src/main/java/com/neastwest/imagesiphon/ImageSiphon.java
+++ b/app/src/main/java/com/neastwest/imagesiphon/ImageSiphon.java
@@ -21,6 +21,7 @@ import java.net.URL;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
+import java.util.UUID;
 
 import static android.content.ContentValues.TAG;
 
@@ -149,6 +150,13 @@ public class ImageSiphon {
         return newImgView;
     }
 
+    public static View createImageViewURI(Uri uri, Context context) {
+        ImageView newImgView = new ImageView(context);
+        newImgView.setImageURI(uri);
+        newImgView.setPadding(5, 5, 5, 5);
+        return newImgView;
+    }
+
     public static void saveThumbToFile(Bitmap image, Context context, File pictureFile) {
         //File pictureFile = getOutputMediaFile(context);
         if (pictureFile == null) {
@@ -185,9 +193,10 @@ public class ImageSiphon {
             }
         }
         // Create a media file name
-        String timeStamp = new SimpleDateFormat("ddMMyyyy_HHmm", Locale.US).format(new Date());
+        String timeStamp = new SimpleDateFormat("ddMMyyyy_HHmmss", Locale.US).format(new Date());
         File mediaFile;
-        String mImageName="MI_"+ timeStamp +".jpg";
+        String uuid = UUID.randomUUID().toString().replaceAll("-", "");
+        String mImageName="MI_"+ timeStamp + uuid + ".jpg";
         mediaFile = new File(mediaStorageDir.getPath() + File.separator + mImageName);
         Log.d("MESSAGE", mediaFile.getPath());
         return mediaFile;

--- a/app/src/main/java/com/neastwest/imagesiphon/ImageSiphon.java
+++ b/app/src/main/java/com/neastwest/imagesiphon/ImageSiphon.java
@@ -9,11 +9,19 @@ import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+import static android.content.ContentValues.TAG;
 
 public class ImageSiphon {
 
@@ -49,12 +57,15 @@ public class ImageSiphon {
     public static View viewCreator(MainActivity.Wrapper w) throws MalformedURLException, IOException {
         Context context = w.getContext();
         URL url = new URL(w.getString());
+        String packageName = w.getPackageName();
         Bitmap newImage;
         //if the URL returns a good HTTP response code, retrieve the
         //image from the URL and then turn it into an ImageView
         if (testURL(url)) {
             Log.d("MESSAGE", "good URL: ");
             newImage = retrieveImage(url);
+            Log.d("MESSAGE", "calling save image function");
+            saveThumbToFile(newImage, context);
             View imgView = createImageView(newImage, context);
             return imgView;
             //Else return an error TextView
@@ -117,4 +128,52 @@ public class ImageSiphon {
         newImgView.setPadding(5, 5, 5, 5);
         return newImgView;
     }
+
+    public static void saveThumbToFile(Bitmap image, Context context) {
+        File pictureFile = getOutputMediaFile(context);
+        if (pictureFile == null) {
+            Log.d(TAG,
+                    "Error creating media file, check storage permissions: ");// e.getMessage());
+            return;
+        }
+        try {
+            FileOutputStream fos = new FileOutputStream(pictureFile);
+            image.compress(Bitmap.CompressFormat.PNG, 90, fos);
+            fos.close();
+            Log.d("MESSAGE", pictureFile.toString());
+        } catch (FileNotFoundException e) {
+            Log.d(TAG, "File not found: " + e.getMessage());
+        } catch (IOException e) {
+            Log.d(TAG, "Error accessing file: " + e.getMessage());
+        }
+    }
+
+    /** Create a File for saving an image or video */
+    private static File getOutputMediaFile(Context context){
+        Log.d("MESSAGE", "reached output media file");
+        // To be safe, you should check that the SDCard is mounted
+        // using Environment.getExternalStorageState() before doing this.
+        File mediaStorageDir = new File(context.getFilesDir().getPath() + "/pics/");
+        Log.d("MESSAGE", "saved storage dir");
+        // This location works best if you want the created images to be shared
+        // between applications and persist after your app has been uninstalled.
+
+        // Create the storage directory if it does not exist
+        if (! mediaStorageDir.exists()){
+            if (! mediaStorageDir.mkdirs()){
+                Log.d("MESSAGE", "returning null on mediaStorageExists");
+                return null;
+            }
+        }
+        // Create a media file name
+        String timeStamp = new SimpleDateFormat("ddMMyyyy_HHmm", Locale.US).format(new Date());
+        File mediaFile;
+        String mImageName="MI_"+ timeStamp +".jpg";
+        mediaFile = new File(mediaStorageDir.getPath() + File.separator + mImageName);
+        Log.d("MESSAGE", mediaFile.getPath());
+        return mediaFile;
+    }
+
+
+
 }

--- a/app/src/main/java/com/neastwest/imagesiphon/MainActivity.java
+++ b/app/src/main/java/com/neastwest/imagesiphon/MainActivity.java
@@ -1,7 +1,7 @@
 package com.neastwest.imagesiphon;
 
-//This is the SaveToStorage branch, if this works...
 
+//Image to Storage feature branch
 import android.content.Context;
 import android.os.AsyncTask;
 import android.support.v7.app.AppCompatActivity;

--- a/app/src/main/java/com/neastwest/imagesiphon/MainActivity.java
+++ b/app/src/main/java/com/neastwest/imagesiphon/MainActivity.java
@@ -129,6 +129,7 @@ public class MainActivity extends AppCompatActivity {
     class Wrapper {
         final Context context = MainActivity.this;
         String imageName = "";
+        String packageName = getApplicationContext().getPackageName();
 
         public void setString(String newName) {
             imageName = newName;
@@ -138,6 +139,9 @@ public class MainActivity extends AppCompatActivity {
         }
         Context getContext() {
             return context;
+        }
+        String getPackageName() {
+            return packageName;
         }
     }
 }

--- a/app/src/main/java/com/neastwest/imagesiphon/MainActivity.java
+++ b/app/src/main/java/com/neastwest/imagesiphon/MainActivity.java
@@ -1,5 +1,7 @@
 package com.neastwest.imagesiphon;
 
+//This is the SaveToStorage branch, if this works...
+
 import android.content.Context;
 import android.os.AsyncTask;
 import android.support.v7.app.AppCompatActivity;

--- a/app/src/main/java/com/neastwest/imagesiphon/MainActivity.java
+++ b/app/src/main/java/com/neastwest/imagesiphon/MainActivity.java
@@ -3,6 +3,7 @@ package com.neastwest.imagesiphon;
 
 //Image to Storage feature branch
 import android.content.Context;
+import android.net.Uri;
 import android.os.AsyncTask;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
@@ -86,7 +87,7 @@ public class MainActivity extends AppCompatActivity {
 
     //AsyncTask to check a URL and return a View.
     //Returns an ImageView for a valid link and a TextView in case of errors.
-    private class ImageDownloader extends AsyncTask <Wrapper, Void, View> {
+    private class ImageDownloader extends AsyncTask <Wrapper, Void, ImageDL> {
         private String newImageUrl = "";
         Wrapper ww = new Wrapper();
 
@@ -96,27 +97,27 @@ public class MainActivity extends AppCompatActivity {
             progBar.setProgress(0);
         }
 
-        protected View doInBackground(Wrapper... imagesURL) {
+        protected ImageDL doInBackground(Wrapper... imagesURL) {
             ww = imagesURL[0];
             Log.i("MESSAGE", newImageUrl);
-            View w = null;
+            ImageDL dl = new MainActivity.ImageDL();
 
             //send new Wrapper object to viewCreator function
             try {
-                w = ImageSiphon.viewCreator(ww);
+                dl = ImageSiphon.viewCreator(ww);
                 Log.i("MESSAGE", "retreive Image worked?");
                 //Catch exception
             } catch (IOException e) {
                 e.printStackTrace();
             }
-            return w;
+            return dl;
         }
 
         //Post Execute will hide the progress bar and
         //Add the View created in the doInBackground process
         //to the imagesLayout LinearLayout
-        protected void onPostExecute(View newView) {
-            imagesLayout.addView(newView);
+        protected void onPostExecute(ImageDL dl) {
+            imagesLayout.addView(dl.getView());
             progBar.setVisibility(View.GONE);
         }
     }
@@ -142,6 +143,39 @@ public class MainActivity extends AppCompatActivity {
         }
         String getPackageName() {
             return packageName;
+        }
+    }
+    static class ImageDL {
+        Uri thumb;
+        Uri fullSize;
+        View view;
+        boolean imgOrTxt;
+
+        public ImageDL(){}
+
+        void setThumb(Uri uri) {
+            thumb = uri;
+        }
+        void setFullSize(Uri uri) {
+            fullSize = uri;
+        }
+        void setView(View newView) {
+            view = newView;
+        }
+        void setImgOrTxt(boolean typeOfView) {
+            imgOrTxt = typeOfView;
+        }
+        Uri getThumb() {
+            return thumb;
+        }
+        Uri getFullSize() {
+            return fullSize;
+        }
+        View getView() {
+            return view;
+        }
+        boolean getImgOrText() {
+            return imgOrTxt;
         }
     }
 }


### PR DESCRIPTION
This will allow the app to save thumbnails to system storage, to be able to save corresponding URIs into bundles and restore them after device rotation/app switching. It updates the Clear button to delete stored images (also deletes on app force close), and it improves the functionality of the progress bar to extend the full duration of downloading all the images instead of just disappearing after the first image.